### PR TITLE
Remove `DeepReadonly`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react-hooks": "^7.0.2",
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/jest": "^27.5.0",
+        "@types/node": "^18.6.1",
         "@types/react": "^18.0.9",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
@@ -1622,9 +1623,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
-      "integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
+      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
       "dev": true
     },
     "node_modules/@types/parse5": {
@@ -8544,9 +8545,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
-      "integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
+      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
       "dev": true
     },
     "@types/parse5": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@testing-library/react-hooks": "^7.0.2",
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/jest": "^27.5.0",
+    "@types/node": "^18.6.1",
     "@types/react": "^18.0.9",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -1,51 +1,16 @@
-/* eslint-disable */
-// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/deep-freeze/index.d.ts
-export type DeepReadonly<T> = T extends Function
-  ? T
-  : { readonly [P in keyof T]: DeepReadonly<T[P]> };
-/* eslint-enable */
-
-/* eslint-disable */
-// https://github.com/substack/deep-freeze/blob/master/index.js
-const deepFreeze = <T>(o: any): DeepReadonly<T> => {
-  // Don't freeze in production for better performance
-  if (process.env.NODE_ENV === 'production') {
-    return o;
-  }
-
-  if (o && (typeof o === 'object' || typeof o === 'function')) {
-    Object.freeze(o);
-    Object.getOwnPropertyNames(o).forEach((prop) => {
-      if (
-        Object.prototype.hasOwnProperty.call(o, prop) &&
-        o[prop] &&
-        (typeof o === 'object' ||
-          (prop !== 'caller' && prop !== 'callee' && prop !== 'arguments')) &&
-        (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
-        !Object.isFrozen(o[prop])
-      ) {
-        deepFreeze(o[prop]);
-      }
-    });
-  }
-
-  return o;
-};
-/* eslint-enable */
-
-export type AtomSubscription<T> = (value: DeepReadonly<T>) => void;
+export type AtomSubscription<T> = (value: T) => void;
 
 export type AtomOptions = {
   name: string;
 };
 
 export class Atom<T> {
-  private _value: DeepReadonly<T>;
+  private _value: T;
   private _subscriptions: AtomSubscription<T>[];
   private _name?: string;
 
   constructor(initialValue: T, opts?: AtomOptions) {
-    this._value = deepFreeze<T>(initialValue);
+    this._value = initialValue;
     this._subscriptions = [];
     this.subscribe = this.subscribe.bind(this);
     this._name = opts?.name;
@@ -55,16 +20,13 @@ export class Atom<T> {
     return this._name;
   }
 
-  // @ts-expect-error - ts(2380) The return type of a 'get' accessor must be assignable to its 'set' accessor type.
-  // 'T' could be instantiated with an arbitrary type which could be unrelated to 'DeepReadonly<T>'.
-  get value(): DeepReadonly<T> {
+  get value(): T {
     return this._value;
   }
 
   set value(value: T) {
-    const nextValue = deepFreeze<T>(value);
-    this._value = nextValue;
-    this._subscriptions.forEach((cb) => cb(nextValue));
+    this._value = value;
+    this._subscriptions.forEach((cb) => cb(value));
   }
 
   subscribe(subscription: AtomSubscription<T>) {

--- a/src/useAtom.ts
+++ b/src/useAtom.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import type { Atom, DeepReadonly } from './Atom';
+import type { Atom } from './Atom';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type SetAtomValue<T> = T extends Function ? (prevState: T) => T : T | ((prevState: T) => T);
 
 /** React hook that returns a tuple with reactive atom value and update function  */
 export const useAtom = <T>(atom: Atom<T>): [typeof state, typeof setValue] => {
-  const [state, setState] = useState<DeepReadonly<T>>(() => atom.value);
+  const [state, setState] = useState<T>(() => atom.value);
 
   useEffect(() => {
     if (state !== atom.value) {

--- a/test/Atom.test.ts
+++ b/test/Atom.test.ts
@@ -125,10 +125,6 @@ describe('Atom', () => {
     const nestedObjectAtom = createAtom<NestedObject>({ parent: { child: 0 } });
     const nestedObjectSubscription: AtomSubscription<NestedObject> = jest.fn(() => ({}));
     nestedObjectAtom.subscribe(nestedObjectSubscription);
-    expect(() => {
-      // @ts-expect-error - ts(2540) Cannot assign to 'child' because it is a read-only property.
-      nestedObjectAtom.value.parent.child = 1;
-    }).toThrowError(TypeError);
     expect(nestedObjectAtom.value.parent.child).toBe(0);
     expect(nestedObjectSubscription).toBeCalledTimes(0);
   });
@@ -138,11 +134,6 @@ describe('Atom', () => {
     const nestedArrayAtom = createAtom<NestedArray>({ parent: [1, 3, 2, 4] });
     const nestedArraySubscription: AtomSubscription<NestedArray> = jest.fn(() => ({}));
     nestedArrayAtom.subscribe(nestedArraySubscription);
-    expect(() => {
-      // @ts-expect-error - ts(2339) Property 'sort' does not exist on type 'readonly number[]'.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      nestedArrayAtom.value.parent.sort();
-    }).toThrowError(TypeError);
     expect(nestedArrayAtom.value.parent).toEqual([1, 3, 2, 4]);
     expect(nestedArraySubscription).toBeCalledTimes(0);
     nestedArrayAtom.value = {


### PR DESCRIPTION
## Remove `DeepReadonly`

Causing more pain than it's worth when developing! Additionally the `DeepReadonly` is really hard to work with.