### PR TITLE
Support SSR out of the box

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#2596be",
     "titleBar.inactiveBackground": "#004a72"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
+<div align="center">
+  <h1>simple-atom</h1>
+  <a href="https://www.npmjs.com/package/simple-atom"><img src="https://img.shields.io/npm/v/simple-atom.svg?style=flat&color=brightgreen" target="_blank" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-black" /></a>
+  <br />
+  <hr />
+</div>
 
-# Simple Atom 
-
-Simple atomic immutable state that can be updated outside React.
-
-[![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://choosealicense.com/licenses/mit/)
-
-Contributions & PRs are always welcome! 🙌
+Simple atomic state that can be updated outside of the React life-cycle.
 
 ## Why use `simple-atom`?
- 
-* Update state **outside of a React component.**
 
-* No need for React Context, store your atoms in **global scope**.
+- Update state **outside of a React component.**
 
-* **Familiar API**, identical usage to `React.setState`.
+- No need for React Context, store your atoms in **global scope**.
 
-* First class **Typescript support**.
+- **Familiar API**, identical usage to `React.setState`.
 
-* **Developer friendly**, atom values are deeply frozen to prevent accidental mutations.
+- First class **Typescript support**.
 
-* It's simple, open source and it's tiny! **<250 bytes** gzipped.
-
+- It's simple, open source and it's tiny! **<250 bytes** gzipped.
 
 ## Installation
 
@@ -29,10 +27,11 @@ Contributions & PRs are always welcome! 🙌
 ```
 
 Please ensure you have installed [`react`](https://github.com/facebook/react) at version `v16.8.0` or higher.
-    
+
 ## Examples
 
 #### Basic usage
+
 ```javascript
 import React from 'react';
 // Import 'simple-atom'
@@ -42,25 +41,19 @@ import { createAtom, useAtom } from 'simple-atom';
 const userAtom = createAtom({ name: 'James', age: 25 });
 
 const MyComponent = () => {
-    // Get current value and setter function with 'useAtom' hook
-    const [user, setUser] = useAtom(userAtom);
+  // Get current value and setter function with 'useAtom' hook
+  const [user, setUser] = useAtom(userAtom);
 
-    if (!user) {
-        return (
-            <h1>You are logged out</h1>
-        );
-    }
+  if (!user) {
+    return <h1>You are logged out</h1>;
+  }
 
-    return (
-        <button onClick={() => setUser(null)}>
-            Logout
-        </button>
-    );
-}
-
+  return <button onClick={() => setUser(null)}>Logout</button>;
+};
 ```
 
 #### Update component state outside of React
+
 ```javascript
 // == MyComponent.jsx ==
 import React from 'react';
@@ -91,48 +84,51 @@ isLoadingAtom.value = true;
 ```
 
 #### Subscribe to state changes
+
 ```javascript
 import React from 'react';
 import { createAtom, useAtom } from 'simple-atom';
 
-const darkModeAtom = createAtom(window.localStorage.getItem('dark-mode') === 'true');
+const darkModeAtom = createAtom(() => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return window.localStorage.getItem('dark-mode') === 'true';
+});
 
 // Add a subscriber that is triggered on atom value change
 darkModeAtom.subscribe((value) => {
-    window.localStorage.setItem('dark-mode', value.toString());
+  window.localStorage.setItem('dark-mode', value.toString());
 });
 
 const MyComponent = () => {
-    const [darkMode, setDarkMode] = useAtom(darkModeAtom);
+  const [darkMode, setDarkMode] = useAtom(darkModeAtom);
 
-    return (
-        <button onClick={() => setDarkMode(!darkMode)}>
-            Toggle dark mode
-        </button>
-    );
-}
-
+  return <button onClick={() => setDarkMode(!darkMode)}>Toggle dark mode</button>;
+};
 ```
 
 #### With Typescript
+
 ```typescript
 import { createAtom } from 'simple-atom';
 
-type User = { name: string, age: number } | null;
+type User = { name: string; age: number } | null;
 
 const userAtom = createAtom<User>({ name: 'James', age: 25 });
-
 ```
 
 ## Acknowledgements
+
 This package was inspired by these projects.
 
- - [React](https://reactjs.org/docs/hooks-reference.html#usestate)
- - [Jotai](https://github.com/pmndrs/jotai)
- - [Recoil](https://recoiljs.org/)
- - [Zustand](https://github.com/pmndrs/zustand)
-
+- [React](https://reactjs.org/docs/hooks-reference.html#usestate)
+- [Jotai](https://github.com/pmndrs/jotai)
+- [Recoil](https://recoiljs.org/)
+- [Zustand](https://github.com/pmndrs/zustand)
 
 ## Authors
 
 - [James Berry (@jlalmes)](https://twitter.com/@jlalmes)
+
+Contributions & PRs are always welcome! 🙌

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -9,8 +9,10 @@ export class Atom<T> {
   private _subscriptions: AtomSubscription<T>[];
   private _name?: string;
 
-  constructor(initialValue: T, opts?: AtomOptions) {
-    this._value = initialValue;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  constructor(initialValue: T extends Function ? () => T : T | (() => T), opts?: AtomOptions) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    this._value = typeof initialValue === 'function' ? initialValue() : initialValue;
     this._subscriptions = [];
     this.subscribe = this.subscribe.bind(this);
     this._name = opts?.name;
@@ -38,5 +40,8 @@ export class Atom<T> {
 }
 
 /** Create a new atom function with options */
-export const createAtom = <T>(initialValue: T, opts?: AtomOptions) =>
-  new Atom<T>(initialValue, opts);
+export const createAtom = <T>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  initialValue: T extends Function ? () => T : T | (() => T),
+  opts?: AtomOptions,
+) => new Atom<T>(initialValue, opts);

--- a/test/useAtom.test.tsx
+++ b/test/useAtom.test.tsx
@@ -50,7 +50,7 @@ describe('useAtom', () => {
 
   test('Can set function types in atom hook', () => {
     const initialFunction = jest.fn(() => ({}));
-    const atom = createAtom<() => void>(initialFunction);
+    const atom = createAtom<() => void>(() => initialFunction);
     const { result } = renderHook(() => useAtom(atom));
     expect(atom.value).toBe(initialFunction);
     expect(result.current[0]).toBe(initialFunction);


### PR DESCRIPTION
> This PR introduces a breaking change.

## Support SSR out of the box

You can now supply the `initialValue` of an `atom` as a function. `README.md` shows example with how this can be used to solve SSR issues.

This PR also tidies up something minor thing I missed in https://github.com/jlalmes/simple-atom/pull/1.

